### PR TITLE
fix: Class.forName()でJDBC Driverを読み込まないとjava.sql.SQLException: No suitable driverが発生する

### DIFF
--- a/src/main/java/dao/DataSourceHolder.java
+++ b/src/main/java/dao/DataSourceHolder.java
@@ -39,6 +39,9 @@ class DataSourceHolder {
   public final DataSource dataSource;
 
   public DataSourceHolder() {
+    // JDBC Driverを読み込む。
+    JdbcDriverLoader.load();
+
     // 環境変数`APP_DB_PROPERTIES_FILENAME`がある場合は、`src/main/resources`配下のそのファイルからDBの接続設定を取得する。
     String propertiesFileName = System.getenv("APP_DB_PROPERTIES_FILENAME");
     if (propertiesFileName == null) {

--- a/src/main/java/dao/JdbcDriverLoader.java
+++ b/src/main/java/dao/JdbcDriverLoader.java
@@ -1,0 +1,15 @@
+package dao;
+
+/**
+ * JDBC Driverを読み込む。
+ */
+class JdbcDriverLoader {
+  static void load() {
+    try {
+      // この行がないと、ビルド時のclasspathにConnector/Jが乗らなくなってしまう。
+      Class.forName("com.mysql.cj.jdbc.Driver");
+    } catch (Exception exception) {
+      throw new RuntimeException(exception);
+    }
+  }
+}


### PR DESCRIPTION
## 変更内容

- JDBC Driverを読み込むための静的メソッドを追加
- DataSourceHolderがそのメソッドを呼ぶようにする。