### PR TITLE
fix: GitHub Actionsのキャッシュサイズがどんどん大きくなっていく問題を修正

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -39,4 +39,12 @@ jobs:
             ${{ secrets.DOCKER_REGISTRY }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}:latest
             ${{ secrets.DOCKER_REGISTRY }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}:${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
### 変更理由

GitHub Actionsのキャッシュサイズがビルドの度に大きくなっていく。

### 変更内容

https://docs.docker.com/build/ci/github-actions/cache/ を参照して書き直し