### PR TITLE
fix: actions: タグがついた時にのみDocker build&pushを実行

### DIFF
--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -1,9 +1,9 @@
-name: Push to Docker Private Registry
+name: Build and Push to Docker Private Registry
 
 on:
   push:
-    branches:
-      - "main"
+    tags: 
+      - 'v*'
 
 jobs:
   push_image:
@@ -30,14 +30,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            name/app
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,format=long
+
       - name: Build and push with cache
         uses: docker/build-push-action@v4
         with:
           context: .
+          tags: ${{ steps.docker_meta.outputs.tags }}
           push: true
-          tags: |
-            ${{ secrets.DOCKER_REGISTRY }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}:latest
-            ${{ secrets.DOCKER_REGISTRY }}/${{ vars.PROJECT_NAME }}/${{ vars.PROJECT_NAME }}:${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 


### PR DESCRIPTION
### 変更の理由

mainブランチにマージすることは多いが、その度にビルドが走るのは無駄なので、タグを付けた時にだけDocker build&pushが実行されるようにしたい。

### 変更内容

`v*`というタグが付いたときにのみDocker build&pushが実行されるようにする。